### PR TITLE
Updating regex to identify sql block

### DIFF
--- a/syntax/proc.vim
+++ b/syntax/proc.vim
@@ -23,7 +23,7 @@ endif
 
 " Oracle Pro C/C++ extensions...so far we just just highlight 
 " EXEC SQL statements.
-syn region procStatement         start="EXEC SQL" end=";"
+syn region procStatement         start="EXEC SQL" end="DECLARE *SECTION *;\|END-EXEC *;"
 
 " Default highlighting
 if version >= 508 || !exists("did_proc_syntax_inits")


### PR DESCRIPTION
currently sql block is not fully highlighted because it identify sql start from "EXEC SQL" and end at occurrence of first semicolon . 
example :
-----------------------------------------------
 EXEC SQL EXECUTE
 BEGIN
       sql_procedure(
                                     :ref_RefNum,
                                     :seq_SeqNum,
                                     :cod_Code,
                                     :cod_Veh,
                                     :cod_FCode
                                  );
 END;
 END-EXEC;
-----------------------
here only : 
EXEC SQL EXECUTE
 BEGIN
       sql_procedure(
                                     :ref_RefNum,
                                     :seq_SeqNum,
                                     :cod_Code,
                                     :cod_Veh,
                                     :cod_FCode
                                  );
this much part is highlighted even if there is more in this block , and "END-EXEC" is also not get highlighted .

My change in regex will allow vim to identify whole block more accurately.